### PR TITLE
오류 수정

### DIFF
--- a/src/main/java/com/heygongc/user/application/UserService.java
+++ b/src/main/java/com/heygongc/user/application/UserService.java
@@ -147,10 +147,10 @@ public class UserService {
         }
 
         // jwt 토큰 발급
-        AuthToken authToken = jwtUtil.generateAuthToken(user.getSeq(), user.getDeviceId());
+        AuthToken authToken = jwtUtil.generateAuthToken(saveUser.getSeq(), saveUser.getDeviceId());
 
         // 토큰 저장
-        saveJwtToken(user.getSeq(), authToken.getRefreshToken());
+        saveJwtToken(saveUser.getSeq(), authToken.getRefreshToken());
 
         return authToken;
     }


### PR DESCRIPTION
* org.hibernate.TransientPropertyValueException: object references an unsaved transient instance - save the transient instance before flushing token을 저장할 때 JPA 연관매핑되는 user 정보가 없었음
userRepository.save 하는 saveUser의 seq를 사용해야 함